### PR TITLE
Allow issuer to be specified in application properties

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -36,7 +36,7 @@ services:
     image: ${REGISTRY_URL}auth:${IMAGE_TAG}
     restart: unless-stopped
     environment:
-      - TZ=${AERIUS_TIMEZONE}
+      - TZ=${TIMEZONE}
       - SPRING_DATASOURCE_URL=jdbc:postgresql://auth-database/aerius_authorization
       - SPRING_DATASOURCE_USERNAME=${DATABASE_USERNAME}
       - SPRING_DATASOURCE_PASSWORD=${DATABASE_PASSWORD}

--- a/source/src/main/java/nl/aerius/authorization/config/SecurityConfig.java
+++ b/source/src/main/java/nl/aerius/authorization/config/SecurityConfig.java
@@ -63,6 +63,9 @@ public class SecurityConfig {
   @Value("${aerius.authorization.clients.register.redirecturi:http://127.0.0.1:8080/authorized}")
   private final List<String> registerRedirectUris = new ArrayList<>();
 
+  @Value("${aerius.authorization.server.issuer:}")
+  private String issuer;
+
   @Bean
   @Order(1)
   public SecurityFilterChain authorizationServerSecurityFilterChain(final HttpSecurity http)
@@ -152,7 +155,11 @@ public class SecurityConfig {
 
   @Bean
   public AuthorizationServerSettings authorizationServerSettings() {
-    return AuthorizationServerSettings.builder().build();
+    final AuthorizationServerSettings.Builder builder = AuthorizationServerSettings.builder();
+    if (issuer != null && !issuer.isEmpty()) {
+      builder.issuer(issuer);
+    }
+    return builder.build();
   }
 
 }

--- a/source/src/main/resources/application.properties
+++ b/source/src/main/resources/application.properties
@@ -11,6 +11,10 @@ spring.flyway.default-schema = auth
 # spring.datasource.username=
 # spring.datasource.password=
 
+#  Properties used to configure the authorization server
+#  Issuer to use when constructing tokens. Can be used to add https explicitly if this isn't added, for instance with our traefik setup on dev
+# aerius.authorization.server.issuer = https://base_url
+
 #  Properties used to configure the Register application as a client.
 #  ID of the client application (should match what is used in Register)
 # aerius.authorization.clients.register.id = register-client


### PR DESCRIPTION
On our dev environment, the issuer is generated with http:// instead of https://, I suspect due to our traefik setup. This way we can at least configure what is used.