### PR TITLE
AER-1741 Adding possibility for federated login

### DIFF
--- a/source/pom.xml
+++ b/source/pom.xml
@@ -76,6 +76,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-oauth2-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jdbc</artifactId>
     </dependency>
     <dependency>

--- a/source/src/main/java/nl/aerius/authorization/federation/FederatedAuthenticationSuccessHandler.java
+++ b/source/src/main/java/nl/aerius/authorization/federation/FederatedAuthenticationSuccessHandler.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.aerius.authorization.federation;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import nl.aerius.authorization.repository.UserRepository;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Component to automatically add new federated users to our database if they were not yet known yet.
+ *
+ * This should help linking new users to roles and such.
+ * It requires the user to login once through their identity provider, after which an admin can configure the proper authorization.
+ */
+@Component
+public class FederatedAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+  private final AuthenticationSuccessHandler delegate;
+
+  private final UserRepository userRepository;
+
+  @Autowired
+  public FederatedAuthenticationSuccessHandler(final UserRepository userRepository, final SavedRequestAwareAuthenticationSuccessHandler delegate) {
+    this.userRepository = userRepository;
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void onAuthenticationSuccess(final HttpServletRequest request, final HttpServletResponse response, final Authentication authentication)
+      throws IOException, ServletException {
+    if (authentication instanceof final OAuth2AuthenticationToken token && authentication.getPrincipal() instanceof final OidcUser user) {
+      handleOidcAuthenticatedUser(token, user);
+    }
+
+    this.delegate.onAuthenticationSuccess(request, response, authentication);
+  }
+
+  private void handleOidcAuthenticatedUser(final OAuth2AuthenticationToken token, final OidcUser user) {
+    final String clientRegistrationId = token.getAuthorizedClientRegistrationId();
+    if ("local".equalsIgnoreCase(clientRegistrationId)) {
+      throw new IllegalArgumentException("Local identity provider shouldn't be used like this: " + clientRegistrationId);
+    }
+    final Optional<Integer> identityProviderId = userRepository.retrieveIdentityProviderId(clientRegistrationId);
+    if (identityProviderId.isEmpty()) {
+      throw new IllegalArgumentException("Identity provider not known in database: " + clientRegistrationId);
+    }
+    if (userRepository.retrieveIdentityProviderUserId(clientRegistrationId, user.getSubject()).isEmpty()) {
+      // Add it as a new user
+      userRepository.persistNewFederatedUser(identityProviderId.get(), user.getSubject(), toRecognizableName(user));
+    }
+  }
+
+  private String toRecognizableName(final OidcUser user) {
+    final Optional<OidcUser> optUser = Optional.of(user);
+    // By documentation the getName method should never return null.
+    // However, during testing it returned same as subject, which is some uuid.
+    // Hence prefer the fullname, and if that's not available try the preferred username.
+    return optUser.map(OidcUser::getFullName)
+        .or(() -> optUser.map(OidcUser::getPreferredUsername))
+        .or(() -> optUser.map(OidcUser::getName))
+        .orElseThrow(() -> new IllegalArgumentException("user has no recognizable name, which is unexpected"));
+  }
+
+}

--- a/source/src/main/java/nl/aerius/authorization/repository/UserRepository.java
+++ b/source/src/main/java/nl/aerius/authorization/repository/UserRepository.java
@@ -45,6 +45,23 @@ public class UserRepository {
         .fetchOptional();
   }
 
+  public Optional<Integer> retrieveIdentityProviderId(final String identityProviderName) {
+    return this.context.select(Tables.IDENTITY_PROVIDERS.IDENTITY_PROVIDER_ID)
+        .from(Tables.IDENTITY_PROVIDERS)
+        .where(Tables.IDENTITY_PROVIDERS.NAME.equalIgnoreCase(identityProviderName))
+        .fetchOptional(Tables.IDENTITY_PROVIDERS.IDENTITY_PROVIDER_ID);
+  }
+
+  public Optional<Integer> retrieveIdentityProviderUserId(final String identityProviderName, final String userReference) {
+    return this.context.select(Tables.USERS.USER_ID)
+        .from(Tables.USERS)
+        .join(Tables.IDENTITY_PROVIDERS).using(Tables.IDENTITY_PROVIDERS.IDENTITY_PROVIDER_ID)
+        .where(
+            Tables.IDENTITY_PROVIDERS.NAME.equalIgnoreCase(identityProviderName),
+            Tables.USERS.IDENTITY_PROVIDER_REFERENCE.eq(userReference))
+        .fetchOptional(Tables.USERS.USER_ID);
+  }
+
   public Set<String> retrieveUserRoles(final String identityProvider, final String userReference) {
     return this.context.select(Tables.ROLES.CODE)
         .from(Tables.ROLES)
@@ -67,6 +84,13 @@ public class UserRepository {
             Tables.IDENTITY_PROVIDERS.NAME.eq(identityProvider),
             Tables.USERS.IDENTITY_PROVIDER_REFERENCE.eq(userReference))
         .fetchSet(Tables.COMPETENT_AUTHORITIES.CODE);
+  }
+
+  public int persistNewFederatedUser(final int identityProviderId, final String userReference, final String userName) {
+    return this.context.insertInto(Tables.USERS,
+        Tables.USERS.IDENTITY_PROVIDER_ID, Tables.USERS.IDENTITY_PROVIDER_REFERENCE, Tables.USERS.NAME)
+        .values(identityProviderId, userReference, userName)
+        .execute();
   }
 
 }

--- a/source/src/main/resources/application.properties
+++ b/source/src/main/resources/application.properties
@@ -23,5 +23,20 @@ spring.flyway.default-schema = auth
 #  List of URLs that can be used as a redirect by the client. If URL is not in the list, redirect won't happen when authorizing.
 # aerius.authorization.clients.register.redirecturi = http://url1/authorized, http://url2/authorized
 
+#  Properties used to configure login (authentication) mechanisms
+#  Using local users and a form to login, default true
+# aerius.authorization.formlogin=true
+#  Using links to other identity providers, requiring client.registration and client.provider properties as well, default false
+# aerius.authorization.federation=false
+#  Spring properties to configure identity provider(s), 
+#spring.security.oauth2.client.provider.[PROVIDER_ID].issuer-uri=https://correct-issuer-uri
+#spring.security.oauth2.client.registration.[REGISTRATION_ID].provider=[PROVIDER_ID]
+#spring.security.oauth2.client.registration.[REGISTRATION_ID].client-name=Some recognizable name for a user
+#spring.security.oauth2.client.registration.[REGISTRATION_ID].client-id=The correct ID, as is configured in the identity provider
+#spring.security.oauth2.client.registration.[REGISTRATION_ID].client-secret=The correct secret, as is configured in the identity provider
+#spring.security.oauth2.client.registration.[REGISTRATION_ID].authorization-grant-type=authorization_code
+#spring.security.oauth2.client.registration.[REGISTRATION_ID].redirect-uri={baseUrl}/{action}/oauth2/code/{registrationId}
+#spring.security.oauth2.client.registration.[REGISTRATION_ID].scope=openid,profile
+
 #  Cors properties
 # aerius.cors.allowedorigins = http://localhost:[*], http://127.0.0.1:[*]

--- a/source/src/main/resources/db/migration/V20230517_01__users_username.sql
+++ b/source/src/main/resources/db/migration/V20230517_01__users_username.sql
@@ -1,0 +1,3 @@
+/* add a name to the users table for future reference */
+
+ALTER TABLE users ADD COLUMN name text;

--- a/source/src/test/java/nl/aerius/authorization/federation/FederatedAuthenticationSuccessHandlerTest.java
+++ b/source/src/test/java/nl/aerius/authorization/federation/FederatedAuthenticationSuccessHandlerTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.aerius.authorization.federation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
+
+import nl.aerius.authorization.repository.UserRepository;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@ExtendWith(MockitoExtension.class)
+class FederatedAuthenticationSuccessHandlerTest {
+
+  private static final String CLIENT_REGISTRATION_ID = "OurLocalClientId";
+  private static final int MATCHING_IDENTITY_PROVIDER_ID = 99;
+  private static final String REFERENCE = "Some-Reference-probably-UUID-ey";
+  private static final String FULL_NAME = "First de Last";
+  private static final String USERNAME = "SomeUserName";
+  private static final String NAME = "Somehow Some Other Name";
+
+  @Mock
+  SavedRequestAwareAuthenticationSuccessHandler delegate;
+  @Mock
+  UserRepository userRepository;
+  @Mock
+  HttpServletRequest request;
+  @Mock
+  HttpServletResponse response;
+  @Mock
+  OidcUser user;
+
+  @InjectMocks
+  FederatedAuthenticationSuccessHandler handler;
+
+  @BeforeEach
+  public void beforeEach() {
+    lenient().when(user.getSubject()).thenReturn(REFERENCE);
+    lenient().when(user.getName()).thenReturn(NAME);
+    lenient().when(user.getFullName()).thenReturn(FULL_NAME);
+    lenient().when(user.getPreferredUsername()).thenReturn(USERNAME);
+  }
+
+  @Test
+  void testSuccesfulNewUser() throws IOException, ServletException {
+    final OAuth2AuthenticationToken authentication = mock(OAuth2AuthenticationToken.class);
+    when(authentication.getPrincipal()).thenReturn(user);
+    when(authentication.getAuthorizedClientRegistrationId()).thenReturn(CLIENT_REGISTRATION_ID);
+
+    when(userRepository.retrieveIdentityProviderId(CLIENT_REGISTRATION_ID)).thenReturn(Optional.of(MATCHING_IDENTITY_PROVIDER_ID));
+    when(userRepository.retrieveIdentityProviderUserId(CLIENT_REGISTRATION_ID, REFERENCE)).thenReturn(Optional.empty());
+
+    handler.onAuthenticationSuccess(request, response, authentication);
+
+    verify(userRepository).persistNewFederatedUser(MATCHING_IDENTITY_PROVIDER_ID, REFERENCE, FULL_NAME);
+    verify(delegate).onAuthenticationSuccess(request, response, authentication);
+  }
+
+  @Test
+  void testSuccesfulNewUserWithoutFullName() throws IOException, ServletException {
+    final OAuth2AuthenticationToken authentication = mock(OAuth2AuthenticationToken.class);
+    when(authentication.getPrincipal()).thenReturn(user);
+    when(authentication.getAuthorizedClientRegistrationId()).thenReturn(CLIENT_REGISTRATION_ID);
+
+    when(userRepository.retrieveIdentityProviderId(CLIENT_REGISTRATION_ID)).thenReturn(Optional.of(MATCHING_IDENTITY_PROVIDER_ID));
+    when(userRepository.retrieveIdentityProviderUserId(CLIENT_REGISTRATION_ID, REFERENCE)).thenReturn(Optional.empty());
+
+    when(user.getFullName()).thenReturn(null);
+
+    handler.onAuthenticationSuccess(request, response, authentication);
+
+    verify(userRepository).persistNewFederatedUser(MATCHING_IDENTITY_PROVIDER_ID, REFERENCE, USERNAME);
+    verify(delegate).onAuthenticationSuccess(request, response, authentication);
+  }
+
+  @Test
+  void testSuccesfulNewUserWithoutFullNameAndUsername() throws IOException, ServletException {
+    final OAuth2AuthenticationToken authentication = mock(OAuth2AuthenticationToken.class);
+    when(authentication.getPrincipal()).thenReturn(user);
+    when(authentication.getAuthorizedClientRegistrationId()).thenReturn(CLIENT_REGISTRATION_ID);
+
+    when(userRepository.retrieveIdentityProviderId(CLIENT_REGISTRATION_ID)).thenReturn(Optional.of(MATCHING_IDENTITY_PROVIDER_ID));
+    when(userRepository.retrieveIdentityProviderUserId(CLIENT_REGISTRATION_ID, REFERENCE)).thenReturn(Optional.empty());
+
+    when(user.getFullName()).thenReturn(null);
+    when(user.getPreferredUsername()).thenReturn(null);
+
+    handler.onAuthenticationSuccess(request, response, authentication);
+
+    verify(userRepository).persistNewFederatedUser(MATCHING_IDENTITY_PROVIDER_ID, REFERENCE, NAME);
+    verify(delegate).onAuthenticationSuccess(request, response, authentication);
+  }
+
+  @Test
+  void testSuccesfulNewUserWithoutAnyNames() throws IOException, ServletException {
+    final OAuth2AuthenticationToken authentication = mock(OAuth2AuthenticationToken.class);
+    when(authentication.getPrincipal()).thenReturn(user);
+    when(authentication.getAuthorizedClientRegistrationId()).thenReturn(CLIENT_REGISTRATION_ID);
+
+    when(userRepository.retrieveIdentityProviderId(CLIENT_REGISTRATION_ID)).thenReturn(Optional.of(MATCHING_IDENTITY_PROVIDER_ID));
+    when(userRepository.retrieveIdentityProviderUserId(CLIENT_REGISTRATION_ID, REFERENCE)).thenReturn(Optional.empty());
+
+    when(user.getFullName()).thenReturn(null);
+    when(user.getPreferredUsername()).thenReturn(null);
+    when(user.getName()).thenReturn(null);
+
+    final IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+        () -> handler.onAuthenticationSuccess(request, response, authentication));
+
+    assertEquals("user has no recognizable name, which is unexpected", e.getMessage());
+    verify(userRepository, never()).persistNewFederatedUser(anyInt(), any(), any());
+    verifyNoInteractions(delegate);
+  }
+
+  @Test
+  void testSuccesfulExistingUser() throws IOException, ServletException {
+    final OAuth2AuthenticationToken authentication = mock(OAuth2AuthenticationToken.class);
+    when(authentication.getPrincipal()).thenReturn(user);
+    when(authentication.getAuthorizedClientRegistrationId()).thenReturn(CLIENT_REGISTRATION_ID);
+
+    when(userRepository.retrieveIdentityProviderId(CLIENT_REGISTRATION_ID)).thenReturn(Optional.of(MATCHING_IDENTITY_PROVIDER_ID));
+    when(userRepository.retrieveIdentityProviderUserId(CLIENT_REGISTRATION_ID, REFERENCE)).thenReturn(Optional.of(88));
+
+    handler.onAuthenticationSuccess(request, response, authentication);
+
+    verify(userRepository, never()).persistNewFederatedUser(anyInt(), any(), any());
+    verify(delegate).onAuthenticationSuccess(request, response, authentication);
+  }
+
+  @Test
+  void testLocalId() throws IOException, ServletException {
+    final OAuth2AuthenticationToken authentication = mock(OAuth2AuthenticationToken.class);
+    when(authentication.getPrincipal()).thenReturn(user);
+    when(authentication.getAuthorizedClientRegistrationId()).thenReturn("local");
+
+    final IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+        () -> handler.onAuthenticationSuccess(request, response, authentication));
+
+    assertEquals("Local identity provider shouldn't be used like this: local", e.getMessage());
+
+    verifyNoInteractions(userRepository);
+    verifyNoInteractions(delegate);
+  }
+
+  @Test
+  void testUnknownClientId() throws IOException, ServletException {
+    final OAuth2AuthenticationToken authentication = mock(OAuth2AuthenticationToken.class);
+    when(authentication.getPrincipal()).thenReturn(user);
+    when(authentication.getAuthorizedClientRegistrationId()).thenReturn(CLIENT_REGISTRATION_ID);
+
+    when(userRepository.retrieveIdentityProviderId(CLIENT_REGISTRATION_ID)).thenReturn(Optional.empty());
+
+    final IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+        () -> handler.onAuthenticationSuccess(request, response, authentication));
+
+    assertEquals("Identity provider not known in database: " + CLIENT_REGISTRATION_ID, e.getMessage());
+
+    verify(userRepository, never()).persistNewFederatedUser(anyInt(), any(), any());
+    verifyNoInteractions(delegate);
+  }
+
+  @Test
+  void testUnknownAuthentication() throws IOException, ServletException {
+    final Authentication authentication = mock(Authentication.class);
+
+    // Shouldn't trigger any exceptions, work as usual
+    handler.onAuthenticationSuccess(request, response, authentication);
+
+    verifyNoInteractions(userRepository);
+    verify(delegate).onAuthenticationSuccess(request, response, authentication);
+  }
+
+  @Test
+  void testUnknownPrincipal() throws IOException, ServletException {
+    final OAuth2AuthenticationToken authentication = mock(OAuth2AuthenticationToken.class);
+    // Currently only supporting Oidc users
+    when(authentication.getPrincipal()).thenReturn(mock(OAuth2User.class));
+
+    // Shouldn't trigger any exceptions, work as usual
+    handler.onAuthenticationSuccess(request, response, authentication);
+
+    verifyNoInteractions(userRepository);
+    verify(delegate).onAuthenticationSuccess(request, response, authentication);
+  }
+
+}


### PR DESCRIPTION
Based on local experimenting with KeyCloak, this allows our auth application to support users that are authenticated by another identity provider. All that is required is the correct configuration...